### PR TITLE
[FIX] Créer une demande d'abo en back-end ne permet pas d'attribuer un abonnement

### DIFF
--- a/product_subscription/demo/demo.xml
+++ b/product_subscription/demo/demo.xml
@@ -4,7 +4,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-    <data noupdate="0">  <!-- fixme -->
+    <data noupdate="0">
         <record id="demo_product_subscription_journal" model="account.journal">
             <field name="name">Subscriptions</field>
             <field name="code">TINV</field>
@@ -82,7 +82,6 @@
             <field name="list_price">25</field>
             <field name="type">service</field>
             <field name="uom_id" ref="product.product_uom_unit"/>
-            <field name="weight_uom_id" ref="product.product_uom_kgm"/>
         </record>
 
         <record id="demo_released_product_2" model="product.template">
@@ -92,7 +91,6 @@
             <field name="list_price">25</field>
             <field name="type">service</field>
             <field name="uom_id" ref="product.product_uom_unit"/>
-            <field name="weight_uom_id" ref="product.product_uom_kgm"/>
         </record>
 
         <record id="demo_released_product_3" model="product.template">
@@ -102,7 +100,6 @@
             <field name="list_price">20</field>
             <field name="type">service</field>
             <field name="uom_id" ref="product.product_uom_unit"/>
-            <field name="weight_uom_id" ref="product.product_uom_kgm"/>
         </record>
 
         <record id="demo_subscriber_1" model="res.partner">

--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -139,10 +139,11 @@ class SubscriptionRequest(models.Model):
         for request in self:
             partner = request.sponsor
             invoice = request.create_invoice(partner, {})
+            request.invoice = invoice
             invoice.compute_taxes()
             invoice.signal_workflow('invoice_open')
             request.send_invoice(invoice)
-            request.write({'state': 'sent', 'invoice': invoice.id})
+            request.state = 'sent'
 
     @api.multi
     def cancel_request(self):

--- a/product_subscription/tests/test_product_subscription.py
+++ b/product_subscription/tests/test_product_subscription.py
@@ -21,3 +21,42 @@ class TestProductSubscription(TransactionCase):
         subscription = request.subscription
         self.assertEqual(subscription.state, 'ongoing')
         self.assertEqual(subscription.subscribed_on, fields.Date.today())
+
+    def test_request_for_free_subscription(self):
+        journal = self.env.ref(
+            'product_subscription.demo_product_subscription_journal')
+        categ = self.env.ref('product.product_category_3')
+        uom = self.env.ref('product.product_uom_unit')
+        partner = self.env.ref('product_subscription.demo_subscriber_4')
+
+        life_product = self.env['product.template'].create({
+            'name': 'lifelong product',
+            'categ_id': categ.id,
+            'sale_ok': True,
+            'list_price': 0,
+            'type': 'service',
+            'uom_id': uom.id,
+            'subscription': True,
+            'product_qty': 4,
+        })
+
+        life_subscription = self.env['product.subscription.template'].create({
+            'name': 'lifelong subscription',
+            'product_qty': 100,
+            'price': 0,
+            'product': life_product.id,
+            'journal': journal.id,
+        })
+
+        request = self.env['product.subscription.request'].create({
+            'subscriber': partner.id,
+            'sponsor': partner.id,
+            'subscription_template': life_subscription.id,
+        })
+
+        request.validate_request()
+
+        self.assertEquals(request.invoice.state, 'paid')
+        self.assertTrue(request.subscription)
+        self.assertEquals(request.subscription.state, 'ongoing')
+        self.assertTrue(len(partner.subscriptions) > 0)

--- a/website_product_subscription_online_payment/controllers/main.py
+++ b/website_product_subscription_online_payment/controllers/main.py
@@ -66,7 +66,13 @@ class SubscribeOnlinePayment(SubscribeController):
                                             "easy_my_coop.cooperator_thanks"),
                                           values)
 
-        return True
+    def get_subscription_request_values(self, params, gift):
+        vals = (
+            super(SubscribeOnlinePayment, self)
+                .get_subscription_request_values(params, gift)
+        )
+        vals['origin'] = 'website'
+        return vals
 
 
 class ProductSubscriptionOnlinePayment(WebsiteProductSubscription):
@@ -153,7 +159,13 @@ class ProductSubscriptionOnlinePayment(WebsiteProductSubscription):
                                             "easy_my_coop.cooperator_thanks"),
                                           values)
 
-        return True
+    def get_subscription_request_values(self, params, gift):
+        vals = (
+            super(ProductSubscriptionOnlinePayment, self)
+            .get_subscription_request_values(params, gift)
+        )
+        vals['origin'] = 'website'
+        return vals
 
 
 class SubscriptionWebsitePayment(website_payment):

--- a/website_product_subscription_online_payment/models/invoice.py
+++ b/website_product_subscription_online_payment/models/invoice.py
@@ -7,8 +7,10 @@ class AccountInvoice(models.Model):
 
     def post_process_confirm_sub_paid(self, effective_date):
         request = self.product_subscription_request
-        if (request.payment_type == 'deferred'
-                and not request.subscription_template.split_payment):
+        if (
+            request.payment_type == "deferred"
+            and not request.subscription_template.split_payment
+        ):
             self.process_subscription(effective_date)
 
         return True

--- a/website_product_subscription_online_payment/models/product_subscription.py
+++ b/website_product_subscription_online_payment/models/product_subscription.py
@@ -1,18 +1,54 @@
 # -*- coding: utf-8 -*-
-from openerp import fields, models
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Houssine Bakkali <houssine@coopiteasy.be>
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+from openerp import fields, models, api
 
 
 class ProductSubscriptionRequest(models.Model):
-    _inherit = 'product.subscription.request'
+    _inherit = "product.subscription.request"
 
-    payment_transaction = fields.One2many('payment.transaction',
-                                          'product_subscription_request_id')
-    transaction_state = fields.Selection(related='payment_transaction.state',
-                                         string="Transaction status")
-    payment_type = fields.Selection(related='payment_transaction.payment_type',
-                                    string='Payment Type')
+    origin = fields.Selection(
+        [("website", "Website"),
+         ("manual", "Manual")],
+        string="Source",
+        default="manual",
+        readonly=True,
+    )
+    payment_transaction = fields.One2many(
+        comodel_name="payment.transaction",
+        inverse_name="product_subscription_request_id",
+    )
+    transaction_state = fields.Selection(
+        related="payment_transaction.state",
+        string="Transaction status",
+    )
+    payment_type = fields.Selection(
+        related="payment_transaction.payment_type",
+        string="Payment Type",
+    )
 
     def send_invoice(self, invoice):
-        if (self.payment_type == 'deferred'
-                or self.subscription_template.split_payment):
+        if (
+            self.payment_type == "deferred"
+            or self.subscription_template.split_payment
+        ):
             super(ProductSubscriptionRequest, self).send_invoice(invoice)
+
+    @api.multi
+    def validate_request(self):
+        super(ProductSubscriptionRequest, self).validate_request()
+        for request in self:
+            if request.origin == 'manual':
+                acquirer = self.env.ref(
+                    'payment_transfer.payment_acquirer_transfer')
+                self.env['payment.transaction'].create({
+                    'reference': request.invoice.number,
+                    'amount': request.invoice.residual,
+                    'currency_id': request.invoice.currency_id.id,
+                    'acquirer_id': acquirer.id,
+                    'product_subscription_request_id': request.id,
+                })

--- a/website_product_subscription_online_payment/tests/__init__.py
+++ b/website_product_subscription_online_payment/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_subscription

--- a/website_product_subscription_online_payment/tests/test_product_subscription.py
+++ b/website_product_subscription_online_payment/tests/test_product_subscription.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+from openerp import fields
+
+
+class TestProductSubscription(TransactionCase):
+
+    def test_create_request_to_manual_origin(self):
+        journal = self.env.ref(
+            'product_subscription.demo_product_subscription_journal')
+        categ = self.env.ref('product.product_category_3')
+        uom = self.env.ref('product.product_uom_unit')
+        partner = self.env.ref('product_subscription.demo_subscriber_4')
+
+        product = self.env['product.template'].create({
+            'name': 'lifelong product',
+            'categ_id': categ.id,
+            'sale_ok': True,
+            'list_price': 0,
+            'type': 'service',
+            'uom_id': uom.id,
+            'subscription': True,
+            'product_qty': 4,
+        })
+
+        subscription = self.env['product.subscription.template'].create({
+            'name': 'lifelong subscription',
+            'product_qty': 100,
+            'price': 0,
+            'product': product.id,
+            'journal': journal.id,
+        })
+
+        request = self.env['product.subscription.request'].create({
+            'subscriber': partner.id,
+            'sponsor': partner.id,
+            'subscription_template': subscription.id,
+        })
+
+        self.assertEquals(request.origin, 'manual')
+
+        request.validate_request()
+
+        self.assertTrue(request.payment_transaction)
+        self.assertEquals(request.payment_transaction.payment_type, 'deferred')


### PR DESCRIPTION
[ref](https://gestion.coopiteasy.be/web#id=3229&view_type=form&model=project.task)

- ddc02b2 : add tests
- 58293f4 : **bug 1**: for a free subscription, the invoice is set to paid and calls `confirm_paid` before invoice is set on the request. The partner is therefore not accessible when creating the subscription.
- 46abd48 **bug 2**: when creating requests in the backend, `payment_transaction` and therefore `transaction_state` and `payment_type` (related fields) are not set. Therefore, process_subscription is never called since `self.payment_type == "deferred"` is always false)

**question** the condition in `ProductSubscriptionRequest.send_invoice` and `invoice.post_process_confirm_sub_paid` are not the same, is that normal?