### PR TITLE
[IMP] cron closes ongoing expired subscriptions

### DIFF
--- a/product_subscription/models/subscription_object.py
+++ b/product_subscription/models/subscription_object.py
@@ -23,7 +23,9 @@ class SubscriptionObject(models.Model):
     counter = fields.Float(string="Counter")
     subscribed_on = fields.Date(string="Subscription date")
     start_date = fields.Date(string="Start Date", required=True)
-    end_date = fields.Date(string="End Date", compute="_compute_date_end")
+    end_date = fields.Date(
+        string="End Date", compute="_compute_date_end", store=True
+    )
     state = fields.Selection(
         [
             ("draft", "Draft"),
@@ -73,7 +75,12 @@ class SubscriptionObject(models.Model):
         return super(SubscriptionObject, self).create(vals)
 
     @api.multi
-    @api.depends("start_date", "template")
+    @api.depends(
+        "start_date",
+        "template",
+        "template.time_span",
+        "template.time_span_unit",
+    )
     def _compute_date_end(self):
         for subscription in self:
             if not subscription.start_date:

--- a/product_subscription_web_access/data/cron.xml
+++ b/product_subscription_web_access/data/cron.xml
@@ -4,7 +4,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>
-    <data noupdate="0">
+    <data noupdate="1">
         <record id="cie_compute_is_web_subscribed" model="ir.cron">
             <field name="name">Update Is Web Subscribed</field>
             <field name="active" eval="True"/>
@@ -14,6 +14,18 @@
             <field name="doall" eval="False"/>
             <field name="model">res.partner</field>
             <field name="function">cron_update_is_web_subscribed</field>
+            <field name="args">()</field>
+        </record>
+
+        <record id="cron_close_web_only_subscriptions" model="ir.cron">
+            <field name="name">Close web only expired subscriptions</field>
+            <field name="active" eval="True"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field> <!-- don't limit the number of calls -->
+            <field name="doall" eval="False"/>
+            <field name="model">product.subscription.object</field>
+            <field name="function">close_web_only_subscriptions</field>
             <field name="args">()</field>
         </record>
     </data>

--- a/product_subscription_web_access/models/subscription.py
+++ b/product_subscription_web_access/models/subscription.py
@@ -4,6 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api
+from datetime import datetime, timedelta
 
 
 class ProductSubscriptionTemplate(models.Model):
@@ -25,6 +26,20 @@ class ProductSubscriptionObject(models.Model):
     is_web_subscription = fields.Boolean(
         related="template.is_web_subscription"
     )
+
+    @api.model
+    def close_web_only_subscriptions(self):
+        today = fields.Date.to_string((datetime.today()))
+
+        subscriptions = self.search(
+            [
+                ("state", "=", "ongoing"),
+                ("counter", "=", 0),
+                ("end_date", "<", today),
+            ]
+        )
+
+        subscriptions.write({"state": "terminated"})
 
 
 class ProductSubscriptionRequest(models.Model):


### PR DESCRIPTION
[ref](https://gestion.coopiteasy.be/web#id=3891&view_type=form&model=project.task)

In original workflow, subscriptions are closed by the product release. Since web only subscriptions (trial subscriptions) don't go through a release, these subs are never terminated.

This cron closes there subs everyday