### PR TITLE
9.0 cancel subscription on invoice unreconcile

### DIFF
--- a/product_subscription/models/__init__.py
+++ b/product_subscription/models/__init__.py
@@ -4,3 +4,4 @@ from . import subscription_template
 from . import subscription_object
 from . import subscription_request
 from . import product_release
+from . import account_move_line

--- a/product_subscription/models/account_move_line.py
+++ b/product_subscription/models/account_move_line.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Houssine Bakkali <houssine@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp import models, api
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    @api.multi
+    def remove_move_reconcile(self):
+        for account_move_line in self:
+            for invoice in account_move_line.payment_id.invoice_ids:
+                if (invoice.id == self.env.context.get('invoice_id')
+                   and account_move_line in invoice.payment_move_line_ids
+                   and invoice.subscription):
+                    sub = invoice.product_subscription_request[0].subscription
+                    sub.action_cancel()
+        return super(AccountMoveLine, self).remove_move_reconcile()

--- a/product_subscription/models/subscription_object.py
+++ b/product_subscription/models/subscription_object.py
@@ -32,6 +32,7 @@ class SubscriptionObject(models.Model):
             ("ongoing", "Ongoing"),
             ("renew", "Need to Renew"),
             ("terminated", "Terminated"),
+            ("cancel", "Cancelled")
         ],
         string="State",
         default="draft",
@@ -103,16 +104,8 @@ class SubscriptionObject(models.Model):
                     _("Timespan unit is not set on template")
                 )
 
-    # todo use write for batch processing
-    # @api.multi
-    # @api.depends('counter')
-    # def _compute_state(self):
-    #     for subscription in self:
-    #         if not subscription.counter:
-    #             subscription.state = 'draft'
-    #         elif subscription.counter == 0:
-    #             subscription.state = 'terminated'
-    #         elif subscription.counter == 1:
-    #             subscription.state = 'renew'
-    #         else:
-    #             subscription.state = 'ongoing'
+    @api.multi
+    def action_cancel(self):
+        self.ensure_one()
+        self.write({"counter": 0, "state": "cancel"})
+        return True

--- a/product_subscription_subscribers/models/invoice.py
+++ b/product_subscription_subscribers/models/invoice.py
@@ -3,7 +3,7 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields, api
+from openerp import models, api
 
 
 class AccountInvoice(models.Model):

--- a/product_subscription_subscribers/models/subscription.py
+++ b/product_subscription_subscribers/models/subscription.py
@@ -3,7 +3,7 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, fields, api
+from openerp import models, fields
 
 
 class SubscriptionRequest(models.Model):


### PR DESCRIPTION
Au délettrage => il faut annuler l’abonnement (changement de statut et/ou compteur à 0)

Cela nécessite de faire un lien entre la facture et l'abonnement et de surcharger la fonction suivante attention avec easy my coop quand même.

https://github.com/odoo/odoo/blob/9.0/addons/account/models/account_move.py#L1015

https://gestion.coopiteasy.be/web#id=3980&view_type=form&model=project.task&action=479