### PR TITLE
[IMP] ps: remove firstname, use partner_firstname

### DIFF
--- a/product_subscription/models/base.py
+++ b/product_subscription/models/base.py
@@ -9,10 +9,6 @@ from openerp import models, fields, api, _
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    firstname = fields.Char(  # fixme how does it interact with module partner_firstname?
-        string="First Name"
-    )
-    lastname = fields.Char(string="Last Name")
     subscriber = fields.Boolean(
         string="Subscriber", compute="_compute_is_subscriber", store=True
     )


### PR DESCRIPTION
In the legacy code, we added firstname and lastname to partners. Those fields are now added by `OCA/partner-contact/partner_firstname` module.

Removing these fields do not delete the data: the actual effect of removed code is  to overload  the existing fields.