### PR TITLE
[FIX] ps: map tax w/ fiscal position

### DIFF
--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -97,6 +97,7 @@ class SubscriptionRequest(models.Model):
 
         account = self._get_account(partner, product)
 
+        taxes = partner.property_account_position_id.map_tax(product.taxes_id)
         res = {
             "name": product.name,
             "account_id": account.id,
@@ -104,7 +105,7 @@ class SubscriptionRequest(models.Model):
             "quantity": qty,
             "uom_id": product.uom_id.id,
             "product_id": product.id or False,
-            "invoice_line_tax_ids": [(6, 0, product.taxes_id.ids)],
+            "invoice_line_tax_ids": [(6, 0, taxes.ids)],
         }
         return res
 

--- a/product_subscription_delivery/models/delivery_carrier.py
+++ b/product_subscription_delivery/models/delivery_carrier.py
@@ -23,28 +23,3 @@ class DeliveryCarrier(models.Model):
             lambda r: r.id in list(country_ids)
         )
         return shipping_countries
-
-    @api.multi
-    def get_price_available_invoice(self, invoice):
-        self.ensure_one()
-        weight = volume = quantity = 0
-        total_delivery = 0.0
-        ProductUom = self.env["product.uom"]
-        for line in invoice.invoice_line_ids:
-            if line.is_delivery:
-                total_delivery += line.price_subtotal
-            if not line.product_id or line.is_delivery:
-                continue
-            qty = ProductUom._compute_qty(
-                line.uom_id.id, line.quantity, line.product_id.uom_id.id
-            )
-            weight += (line.product_id.weight or 0.0) * qty
-            volume += (line.product_id.volume or 0.0) * qty
-            quantity += qty
-        total = (invoice.amount_total or 0.0) - total_delivery
-
-        total = invoice.currency_id.with_context(
-            date=invoice.date_invoice
-        ).compute(total, invoice.company_id.currency_id)
-
-        return self.get_price_from_picking(total, weight, volume, quantity)

--- a/product_subscription_delivery/models/invoice.py
+++ b/product_subscription_delivery/models/invoice.py
@@ -22,69 +22,6 @@ class AccountInvoice(models.Model):
             [("invoice_id", "in", self.ids), ("is_delivery", "=", True)]
         ).unlink()
 
-    @api.multi
-    def delivery_set(self, quantity=1):
-
-        # Remove delivery lines from the invoice
-        self._delivery_unset()
-
-        for invoice in self:
-            carrier = invoice.carrier_id
-            if carrier:
-                if invoice.state not in ("draft", "sent"):
-                    raise UserError(_("The invoice state have to be draft to"
-                                      "add delivery lines."))
-
-                # The delivery type is based on fixed price
-                carrier = invoice.carrier_id.verify_carrier(
-                    invoice.address_shipping_id
-                )
-                if not carrier:
-                    raise UserError(_("No carrier matching."))
-                price_unit = carrier.get_price_available_invoice(invoice)
-                if invoice.company_id.currency_id.id != invoice.currency_id.id:
-                    price_unit = invoice.company_id.currency_id.with_context(
-                        date=invoice.date_invoice
-                    ).compute(price_unit, invoice.currency_id)
-
-                invoice._create_delivery_line(carrier, price_unit, quantity)
-
-            else:
-                raise UserError(_("No carrier set for this invoice."))
-
-        return True
-
-    def _create_delivery_line(self, carrier, price_unit, quantity):
-        invoice_line_obj = self.env["account.invoice.line"]
-
-        # Apply fiscal position
-        taxes = carrier.product_id.taxes_id.filtered(
-            lambda t: t.company_id.id == self.company_id.id
-        )
-        taxes_ids = taxes.ids
-        if self.partner_id and self.fiscal_position_id:
-            taxes_ids = self.fiscal_position_id.map_tax(taxes).ids
-
-        account = self.env["product.subscription.request"]._get_account(
-            self.address_shipping_id, carrier.product_id
-        )
-
-        # Create the sale order line
-        values = {
-            "invoice_id": self.id,
-            "name": carrier.name,
-            "quantity": quantity,
-            "uom_id": carrier.product_id.uom_id.id,
-            "account_id": account.id,
-            "product_id": carrier.product_id.id,
-            "price_unit": price_unit,
-            "invoice_line_tax_ids": [(6, 0, taxes_ids)],
-            "is_delivery": True,
-        }
-        if self.invoice_line_ids:
-            values["sequence"] = self.invoice_line_ids[-1].sequence + 1
-        return invoice_line_obj.sudo().create(values)
-
 
 class AccountInvoiceLine(models.Model):
     _inherit = "account.invoice.line"

--- a/product_subscription_delivery/models/subscription.py
+++ b/product_subscription_delivery/models/subscription.py
@@ -28,8 +28,12 @@ class SubscriptionRequest(models.Model):
     def onchange_carrier(self):
         if self.carrier_id:
             if not self.carrier_id.verify_carrier(self.subscriber):
-                raise UserError(_("This carrier is not available for this"
-                                  "subscriber. Please select another one"))
+                raise UserError(
+                    _(
+                        "This carrier is not available for this"
+                        "subscriber. Please select another one"
+                    )
+                )
             else:
                 available_carriers = self.get_available_carriers(
                     self.subscriber
@@ -42,17 +46,49 @@ class SubscriptionRequest(models.Model):
             vals = {}
 
         if self.carrier_id:
-            vals["carrier_id"] = self.carrier_id.id
+            carrier = self.carrier_id
         else:
             available_carriers = self.get_available_carriers(self.subscriber)
             if available_carriers:
                 self.carrier_id = available_carriers[0]
-                vals["carrier_id"] = self.carrier_id.id
+                carrier = self.carrier_id
+
+        if not carrier:
+            raise UserError(_("No carrier matching."))
+
+        # The delivery type is based on fixed price
+        carrier.verify_carrier(self.subscriber)
+        delivery_product = carrier.product_id
+        quantity = self.subscription_template.product_qty
+
+        subscription_product = self.subscription_template.product.product_variant_ids[
+            0
+        ]
+        weight = (subscription_product.weight or 0.0) * quantity
+        volume = (subscription_product.volume or 0.0) * quantity
+        price_unit = carrier.get_price_from_picking(
+            subscription_product.list_price, weight, volume, quantity
+        )
+
+        # todo do we need to convert price_unit using currency?
+
+        delivery_line = self._prepare_invoice_line(
+            delivery_product,
+            self.subscriber,
+            quantity=quantity,
+            price_unit=price_unit,
+            is_delivery=True,
+        )
+
+        if "invoice_line_ids" in vals:
+            vals["invoice_line_ids"].append((0, 0, delivery_line))
+        else:
+            vals["invoice_line_ids"] = [(0, 0, delivery_line)]
+
+        vals["carrier_id"] = carrier.id
         vals["address_shipping_id"] = self.subscriber.id
+
         invoice = super(SubscriptionRequest, self).create_invoice(
             partner, vals
         )
-        invoice.delivery_set(self.subscription_template.product_qty)
-        invoice.compute_taxes()
-
         return invoice


### PR DESCRIPTION
[tache](https://gestion.coopiteasy.be/web#id=5031&view_type=form&model=project.task&menu_id=338&action=479)

Yo @houssine78 

En bref, avant:
- la tax sur la facture est celle configurée sur produit de la souscription
- elle n'es pas adaptée en fonction de la position fiscale [exemple en test](https://medor.coopiteasy.be/web#id=19326&view_type=form&model=account.invoice)

**Premier essai** de résolution https://github.com/coopiteasy/product-subscription/pull/25/commits/f631d46529908e174bb2f4a798438ecaf660d16f

- j'appelle map_tax pour choper la taxe correspondant au régime fiscal
- dans le code, je constate que je récupère la bonne taxe
- pourtant la taxe n'apparait pas sur la facture ([exemple](https://medor.coopiteasy.be/web#id=19334&view_type=form&model=account.invoice))
- la tax n'est pas non plus settée sur `invoice.invoice_line_ids.invoice_line_tax_ids` à la ligne 146 alors que dans `vals`, ça apparait.
- par contre ça marche toujours pour le régime national

**Deuxième essai** de résolution https://github.com/coopiteasy/product-subscription/pull/25/commits/eb2fccbed83cf556f33a312b3f24895d1ca22c64

- je comprends que la fonction `invoice.compute_taxes` retire les taxes déjà assignées à la facture
- je remarque que `compute_taxes` est appelée
  1. dans le create du modèle invoice (`invoice.create({...})`)
  2. dans `subscription_request.create_invoice` (module product_subscription) après l'appel à `invoice.create({...})`
  3. dans `subscription_request.create_invoice` (module product_subscription_delivery) après l'appel à `super().create_invoice()`

Donc je me dis que les appels successifs à compute_taxes foutent le bordel et je m'arrange pour que les lignes de facturation soient créées directement depuis le dictionnaire "vals" passé à` invoice.create`. Comme ça il n'y a plus qu'un seul appel à compute_taxes.

Mais, même problème, 
- si je ne fais pas le `map_tax`: les deux lignes avec les bons produits et taxes sont dans les vals et dans la facture créée
- si je fais le `map_tax`: les deux lignes avec les bons produits et taxes sont dans les vals et mais, dans la facture,
  - la ligne de livraison a le bon produit et la bonne taxe,
  - la ligne de produit a le bon produit mais aucune taxe.

Je cale,  j'ai besoin  de tes power.