### PR TITLE
[FIX] fix the invoice line tax created by subscription request

### DIFF
--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -97,6 +97,15 @@ class SubscriptionRequest(models.Model):
 
         account = self._get_account(partner, product)
 
+        # Apply fiscal position
+        taxes = product.taxes_id.filtered(
+            lambda t: t.company_id.id == self.env.user.company_id.id
+        )
+        taxes_ids = taxes.ids
+
+        if partner and partner.property_account_position_id:
+            taxes_ids = partner.property_account_position_id.map_tax(taxes).ids
+
         res = {
             "name": product.name,
             "account_id": account.id,
@@ -104,7 +113,7 @@ class SubscriptionRequest(models.Model):
             "quantity": qty,
             "uom_id": product.uom_id.id,
             "product_id": product.id or False,
-            "invoice_line_tax_ids": [(6, 0, product.taxes_id.ids)],
+            "invoice_line_tax_ids": [(6, 0, taxes_ids)],
         }
         return res
 

--- a/product_subscription_delivery/models/subscription.py
+++ b/product_subscription_delivery/models/subscription.py
@@ -38,6 +38,12 @@ class SubscriptionRequest(models.Model):
                     self.carrier_id = available_carriers[0]
 
     def create_invoice(self, partner, vals=None):
+        # todo
+        #  in this PR: https://github.com/coopiteasy/product-subscription/pull/25  # noqa
+        #  improvements were made to invoice creation.
+        #  Those changes wer not taken into account because they
+        #  did not fix the original issue. Please include these changes
+        #  when migrating / improving code
         if vals is None:
             vals = {}
 


### PR DESCRIPTION
This pull request bring a fix during invoice generation from the subscription request. The tax wasn't correct in the case of a different fiscal position like for intra or extra comm.

This case is now taken into account.