### PR TITLE
[FIX] wps_online_payment: reintroduce payment routes

### DIFF
--- a/website_product_subscription_online_payment/controllers/main.py
+++ b/website_product_subscription_online_payment/controllers/main.py
@@ -76,6 +76,45 @@ class SubscribeOnlinePayment(SubscribeController):
         vals["origin"] = "website"
         return vals
 
+    @http.route(
+        ["/render/online_payment_success"],
+        type="http",
+        auth="public",
+        website=True,
+    )
+    def render_online_payment_success(self, **kw):
+        values = self.preRenderThanks({}, kw)
+        return request.website.render(_RETURN_SUCCESS, values)
+
+    @http.route(
+        ["/render/online_payment_cancel"],
+        type="http",
+        auth="public",
+        website=True,
+    )
+    def render_online_payment_cancel(self, **kw):
+        values = self.preRenderThanks({}, kw)
+        return request.website.render(_RETURN_CANCEL, values)
+
+    @http.route(
+        ["/render/online_payment_error"],
+        type="http",
+        auth="public",
+        website=True,
+    )
+    def render_online_payment_error(self, **kw):
+        values = self.preRenderThanks({}, kw)
+        return request.website.render(_RETURN_ERROR, values)
+
+    def preRenderThanks(self, values, kw):
+        """Fill values for rendering thanks messages."""
+        values = super(SubscribeOnlinePayment, self).preRenderThanks(
+            values, kw
+        )
+        values["redirect_payment"] = request.session.get(
+            "redirect_payment", ""
+        )
+        return values
 
 
 class SubscriptionWebsitePayment(website_payment):

--- a/website_product_subscription_online_payment/views/online_payment_template.xml
+++ b/website_product_subscription_online_payment/views/online_payment_template.xml
@@ -52,7 +52,7 @@
             </div>
         </xpath>
     </template>
-	
+
 	<template id="website_product_subscription_online_payment.SubscriptionOnlinePayment" name="Subscription Online Payment" page="True">
 		<a t-if="invoice.state == 'open'" t-attf-href="/website_payment/pay?reference=#{invoice.number}&amp;amount=#{invoice.residual}&amp;currency_id=#{invoice.currency_id.id}&amp;acquirer_id=#{acquirer_id}&amp;country_id=#{invoice.partner_id.country_id.id}" alt="Pay Now" class="btn btn-xs btn-primary"><i class="fa fa-arrow-circle-right"/> Pay Now</a>
 	</template>


### PR DESCRIPTION
Commit https://github.com/coopiteasy/product-subscription/commit/af8fe0177e12d11ad3235a6fbbf8475974e78946 removed deprecated controller without reintroducing defined routes.

This fix 
- reintroduces the routes in the correct controller
- ~~add payment  info div in the 3 templates~~