### PR TITLE
[9.0] handle gifted subscriber exists in forms

### DIFF
--- a/product_subscription/models/account_move_line.py
+++ b/product_subscription/models/account_move_line.py
@@ -15,10 +15,9 @@ class AccountMoveLine(models.Model):
         # and we set back subscription request state to sent.
         for aml in self:
             invoice = aml.matched_debit_ids.debit_move_id.invoice_id
-            if (aml in invoice.payment_move_line_ids
-               and invoice.subscription):
+            if aml in invoice.payment_move_line_ids and invoice.subscription:
                 sub_req = invoice.product_subscription_request[0]
                 if sub_req.subscription:
                     sub_req.subscription.action_cancel()
-                sub_req.state = 'sent'
+                sub_req.state = "sent"
         return super(AccountMoveLine, self).remove_move_reconcile()

--- a/product_subscription/models/subscription_object.py
+++ b/product_subscription/models/subscription_object.py
@@ -32,7 +32,7 @@ class SubscriptionObject(models.Model):
             ("ongoing", "Ongoing"),
             ("renew", "Need to Renew"),
             ("terminated", "Terminated"),
-            ("cancel", "Cancelled")
+            ("cancel", "Cancelled"),
         ],
         string="State",
         default="draft",

--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -40,15 +40,13 @@ class SubscriptionRequest(models.Model):
         default=lambda _: fields.Date.today(),
     )
     payment_date = fields.Date(
-        string="Payment date",
-        readonly=True,
-        copy=False
+        string="Payment date", readonly=True, copy=False
     )
     invoice = fields.Many2one(
         comodel_name="account.invoice",
         string="Invoice",
         readonly=True,
-        copy=False
+        copy=False,
     )
     state = fields.Selection(
         [
@@ -138,7 +136,9 @@ class SubscriptionRequest(models.Model):
             invoicee = partner
 
         if invoicee.child_ids.filtered(lambda p: p.type == "invoice"):
-            invoicee = invoicee.child_ids.filtered(lambda p: p.type == "invoice")[0]
+            invoicee = invoicee.child_ids.filtered(
+                lambda p: p.type == "invoice"
+            )[0]
         else:
             invoicee = partner
 

--- a/product_subscription/tests/test_product_release.py
+++ b/product_subscription/tests/test_product_release.py
@@ -8,10 +8,10 @@ import datetime as dt
 
 
 class TestProductRelease(TransactionCase):
-
     def test_product_release_cycle(self):
         self.assertTrue(True)
         # too slow
+
     #     release_date = dt.date.today() + dt.timedelta(days=30)
     #     product_id = self.ref('product_subscription.demo_released_product_1')
     #     template_id = self.ref('product_subscription.demo_subscription_template_1')
@@ -37,4 +37,4 @@ class TestProductRelease(TransactionCase):
     #     self.assertEqual(release.state, 'done')
     #     self.assertEqual(len(release.picking_ids), 2)
 
-        # release.action_transfer()  # todo assign stock on product
+    # release.action_transfer()  # todo assign stock on product

--- a/product_subscription_delivery/__openerp__.py
+++ b/product_subscription_delivery/__openerp__.py
@@ -6,7 +6,11 @@
 {
     "name": "Product Subscription Delivery",
     "version": "9.0.1.0.1",
-    "depends": ["product_subscription", "website_product_subscription", "delivery"],
+    "depends": [
+        "product_subscription",
+        "website_product_subscription",
+        "delivery",
+    ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Sales",
     "website": "https://www.coopiteasy.be",

--- a/product_subscription_delivery/models/invoice.py
+++ b/product_subscription_delivery/models/invoice.py
@@ -32,8 +32,12 @@ class AccountInvoice(models.Model):
             carrier = invoice.carrier_id
             if carrier:
                 if invoice.state not in ("draft", "sent"):
-                    raise UserError(_("The invoice state have to be draft to"
-                                      "add delivery lines."))
+                    raise UserError(
+                        _(
+                            "The invoice state have to be draft to"
+                            "add delivery lines."
+                        )
+                    )
 
                 # The delivery type is based on fixed price
                 carrier = invoice.carrier_id.verify_carrier(

--- a/product_subscription_delivery/models/subscription.py
+++ b/product_subscription_delivery/models/subscription.py
@@ -28,8 +28,12 @@ class SubscriptionRequest(models.Model):
     def onchange_carrier(self):
         if self.carrier_id:
             if not self.carrier_id.verify_carrier(self.subscriber):
-                raise UserError(_("This carrier is not available for this"
-                                  "subscriber. Please select another one"))
+                raise UserError(
+                    _(
+                        "This carrier is not available for this"
+                        "subscriber. Please select another one"
+                    )
+                )
             else:
                 available_carriers = self.get_available_carriers(
                     self.subscriber

--- a/product_subscription_subscribers/__openerp__.py
+++ b/product_subscription_subscribers/__openerp__.py
@@ -10,7 +10,7 @@
     "author": "Coop IT Easy SCRLfs",
     "website": "https://coopiteasy.be",
     "license": "AGPL-3",
-    "depends": ["product_subscription", "website_product_subscription"], #
+    "depends": ["product_subscription", "website_product_subscription"],
     "data": [
         "templates/product_subscription_template.xml",
         "views/subscription_views.xml",

--- a/product_subscription_web_access/__openerp__.py
+++ b/product_subscription_web_access/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Product Subscription Web Access",
     "version": "9.0.2.0.1",
-    "depends": ["product_subscription", "website_product_subscription"], #
+    "depends": ["product_subscription", "website_product_subscription"],
     "author": "Coop IT Easy SCRLfs",
     "category": "Sales",
     "website": "https://www.coopiteasy.be",

--- a/product_subscription_web_access/controllers/main.py
+++ b/product_subscription_web_access/controllers/main.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp.addons.website_product_subscription.controllers.subscribe import (
-    SubscribeController
+    SubscribeController,
 )
 from openerp import http
 from openerp.http import request

--- a/product_subscription_web_access/controllers/subscribe.py
+++ b/product_subscription_web_access/controllers/subscribe.py
@@ -5,12 +5,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp.http import request
-from openerp.addons.website_product_subscription.controllers.subscribe import SubscribeController
+from openerp.addons.website_product_subscription.controllers.subscribe import (
+    SubscribeController,
+)
 
 
 class SubscribeWebAccess(SubscribeController):
     def get_subscription_request_values(self):
-        vals = super(SubscribeWebAccess, self).get_subscription_request_values()
+        vals = super(
+            SubscribeWebAccess, self
+        ).get_subscription_request_values()
         params = request.params
         if params["is_gift"]:
             vals["websubscriber"] = params["subscriber_id"]

--- a/website_product_subscription/__openerp__.py
+++ b/website_product_subscription/__openerp__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Website Product Subscription",
-    "version": "9.0.2.0.1",
+    "version": "9.0.2.1.0",
     "depends": [
         "base",
         "website",

--- a/website_product_subscription/controllers/subscribe.py
+++ b/website_product_subscription/controllers/subscribe.py
@@ -311,7 +311,9 @@ class SubscribeController(http.Controller):
                     "email": params["login"],
                 }
             )
-            company = request.env["res.partner"].sudo().create(shipping_address)
+            company = (
+                request.env["res.partner"].sudo().create(shipping_address)
+            )
             request.env.user.parent_id = company
         else:
             shipping_address.update(
@@ -322,7 +324,9 @@ class SubscribeController(http.Controller):
                     "email": params["login"],
                 }
             )
-            company = request.env["res.partner"].sudo().create(shipping_address)
+            company = (
+                request.env["res.partner"].sudo().create(shipping_address)
+            )
 
         params["company_id"] = company.id if company else False
         return company
@@ -352,7 +356,11 @@ class SubscribeController(http.Controller):
                     "lastname": params["lastname"],
                 }
             )
-            representative = request.env["res.partner"].sudo().create(representative_address)
+            representative = (
+                request.env["res.partner"]
+                .sudo()
+                .create(representative_address)
+            )
 
         params["sponsor_id"] = representative.id if representative else False
         return representative

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -76,7 +76,7 @@ class SubscribeForm:
                 "That does not seem to be an email address."
             )
 
-    def _validate_email_unique(self, email):
+    def _validate_sponsor_email_unique(self, email):
         other_users = (
             request.env["res.users"].sudo().search([("login", "=", email)])
         )
@@ -85,6 +85,15 @@ class SubscribeForm:
                 "There is an existing account for this mail "
                 "address. Please login before fill in the form"
             )
+
+    def _validate_subscriber_email_unique(self, email):
+        other_user = (
+            request.env["res.users"]
+            .sudo()
+            .search([("login", "=", email)], limit=1)
+        )
+        if other_user:
+            self.qcontext["gift_subscriber_exists"] = True
 
     def _validate_email_confirmation(self, email, confirm_email):
         if self.confirm:
@@ -123,13 +132,13 @@ class SubscribeForm:
             email = self.qcontext.get("login", False)
             confirm_email = self.qcontext.get("confirm_login")
             self._validate_email_format(email)
-            self._validate_email_unique(email)
+            self._validate_sponsor_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("subscriber_login", False):
             email = self.qcontext.get("subscriber_login", "")
             confirm_email = self.qcontext.get("subscriber_confirm_login")
             self._validate_email_format(email)
-            self._validate_email_unique(email)
+            self._validate_subscriber_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("vat", False):
             vat = self.qcontext.get("vat")

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -127,9 +127,7 @@ class SubscribeForm:
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("subscriber_login", False):
             email = self.qcontext.get("subscriber_login", "")
-            confirm_email = self.qcontext.get(
-                    "subscriber_confirm_login"
-                )
+            confirm_email = self.qcontext.get("subscriber_confirm_login")
             self._validate_email_format(email)
             self._validate_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
@@ -232,11 +230,11 @@ class SubscribeForm:
                     self.qcontext["invoice_address"] = False
         else:
             default_country_id = (
-                    request.env["res.company"]
-                    .sudo()
-                    ._company_default_get()
-                    .country_id.id
-                )
+                request.env["res.company"]
+                .sudo()
+                ._company_default_get()
+                .country_id.id
+            )
             if "country_id" not in self.qcontext or force:
                 self.qcontext["country_id"] = default_country_id
             if "inv_country_id" not in self.qcontext or force:

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -96,7 +96,7 @@ class SubscribeForm:
     def _validate_recaptcha(self):
         if self.captcha_check and "g-recaptcha-response" in self.qcontext:
             if not request.website.is_captcha_valid(
-                self.qcontext.get("g-recaptcha-response", "")
+                    self.qcontext.get("g-recaptcha-response", "")
             ):
                 self.qcontext["error"] = _(
                     "The captcha has not been validated, please fill "
@@ -155,8 +155,8 @@ class SubscribeForm:
                 "countries": self.get_countries(),
                 "subscriptions": (
                     request.env["product.subscription.template"]
-                    .sudo()
-                    .search([("publish", "=", True)])
+                        .sudo()
+                        .search([("publish", "=", True)])
                 ),
                 "company_condition_text": company_condition_text,
                 "user": self.user,
@@ -168,6 +168,13 @@ class SubscribeForm:
         Populate qcontext with the default value for the form. If user
         is set the default values are values of the user.
         """
+        default_country_id = (
+            request.env["res.company"]
+                .sudo()
+                ._company_default_get()
+                .country_id.id
+        )
+
         if self.user:
             user = None
             representative = None
@@ -193,7 +200,7 @@ class SubscribeForm:
                     self.qcontext["country_id"] = (
                         representative.country_id.id
                         if representative.country_id
-                        else 0
+                        else default_country_id
                     )
                 if "vat" not in self.qcontext or force:
                     self.qcontext["vat"] = user.vat
@@ -209,7 +216,7 @@ class SubscribeForm:
                         self.qcontext["inv_country_id"] = (
                             inv_address.country_id.id
                             if inv_address.country_id
-                            else 0
+                            else default_country_id
                         )
                     if "inv_zip_code" not in self.qcontext or force:
                         self.qcontext["inv_zip_code"] = inv_address.zip
@@ -228,19 +235,13 @@ class SubscribeForm:
                         self.qcontext[key] = getattr(user, key)
                 if "invoice_address" not in self.qcontext or force:
                     self.qcontext["invoice_address"] = False
-        else:
-            default_country_id = (
-                request.env["res.company"]
-                .sudo()
-                ._company_default_get()
-                .country_id.id
-            )
-            if "country_id" not in self.qcontext or force:
-                self.qcontext["country_id"] = default_country_id
-            if "inv_country_id" not in self.qcontext or force:
-                self.qcontext["inv_country_id"] = default_country_id
-            if "subscriber_country_id" not in self.qcontext or force:
-                self.qcontext["subscriber_country_id"] = default_country_id
+
+        if "country_id" not in self.qcontext or force:
+            self.qcontext["country_id"] = default_country_id
+        if "inv_country_id" not in self.qcontext or force:
+            self.qcontext["inv_country_id"] = default_country_id
+        if "subscriber_country_id" not in self.qcontext or force:
+            self.qcontext["subscriber_country_id"] = default_country_id
 
     @property
     def user_fields(self):

--- a/website_product_subscription/templates/subscribe_gift_form.xml
+++ b/website_product_subscription/templates/subscribe_gift_form.xml
@@ -11,6 +11,7 @@
                 <form method="post" class="row">
                     <input type="hidden" name="csrf_token"
                            t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="is_gift" t-att-value="'on'"/>
 
                     <p class="alert alert-danger col-lg-12" t-if="error"
                        role="alert">

--- a/website_product_subscription/templates/subscribe_thanks.xml
+++ b/website_product_subscription/templates/subscribe_thanks.xml
@@ -17,6 +17,13 @@
                                 <div class="alert alert-success">
                                     Your subscription has been successfully
                                     registered.
+                                    <t t-if="gift_subscriber_exists">
+                                        <div>
+                                            <span t-esc="sponsor_login"/>
+                                            was already in registered. He/she will
+                                            have the opportunity to check the delivery address in the gift email.
+                                        </div>
+                                    </t>
                                 </div>
                                 <div t-if="redirect_payment"
                                      class="oe_return_button">

--- a/website_product_subscription/tests/test_basic_route.py
+++ b/website_product_subscription/tests/test_basic_route.py
@@ -12,7 +12,6 @@ _logger = logging.getLogger(__name__)
 
 
 class TestBasicRoute(BaseProductSubscriptionCase):
-
     def test_new_subscription_basic_route_person(self):
         route = "/new/subscription/basic"
 

--- a/website_product_subscription_mollie_payment/__openerp__.py
+++ b/website_product_subscription_mollie_payment/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Website Product Subscription Mollie Payment",
     "version": "9.0.2.0.1",
     "depends": [
-        "website_product_subscription", #
+        "website_product_subscription",
         "website_product_subscription_online_payment",
         "payment_mollie_official",
     ],

--- a/website_product_subscription_mollie_payment/controllers/main.py
+++ b/website_product_subscription_mollie_payment/controllers/main.py
@@ -22,7 +22,7 @@ class ProductSubscriptionMollieController(MollieController):
         orderid = post["reference"]
         tx = pay_tx_obj.sudo().search([("reference", "=", orderid)])
         if tx and tx.product_subscription_request_id:
-            _logger.info('mollie redirect : tx status is %s' % tx.state)
+            _logger.info("mollie redirect : tx status is %s" % tx.state)
             if tx.state == "done":
                 route = "/render/online_payment_success"
             elif tx.state == "cancel":
@@ -30,8 +30,9 @@ class ProductSubscriptionMollieController(MollieController):
             elif tx.state == "error":
                 route = "/render/online_payment_error"
         elif tx:
-            _logger.info('mollie redirect : tx status is %s' % tx.state)
+            _logger.info("mollie redirect : tx status is %s" % tx.state)
         else:
-            _logger.info('mollie redirect : no tx found for reference %s' %
-                         orderid)
+            _logger.info(
+                "mollie redirect : no tx found for reference %s" % orderid
+            )
         return werkzeug.utils.redirect(route)

--- a/website_product_subscription_online_payment/controllers/main.py
+++ b/website_product_subscription_online_payment/controllers/main.py
@@ -19,9 +19,7 @@ class SubscribeOnlinePayment(SubscribeController):
         published_aquirers = pay_acq.search([("website_published", "=", True)])
         payment_types = []
         for acquirer in published_aquirers:
-            payment_types.append(
-                [acquirer.provider, acquirer.name.title()]
-            )
+            payment_types.append([acquirer.provider, acquirer.name.title()])
         return payment_types
 
     def fill_values(self, values, load_from_user=False):

--- a/website_product_subscription_online_payment/models/invoice.py
+++ b/website_product_subscription_online_payment/models/invoice.py
@@ -20,13 +20,20 @@ class AccountInvoice(models.Model):
                     ("origin", "=", invoice.move_name),
                 ]
             )
-            if sub_request.payment_transaction or not invoice.subscription \
-                    or refund:
+            if (
+                sub_request.payment_transaction
+                or not invoice.subscription
+                or refund
+            ):
                 super(AccountInvoice, invoice).confirm_paid()
             elif invoice.residual > 0 and not sub_request.payment_transaction:
-                raise ValidationError(_("Can't confirm the payment. There is "
-                                        "no transaction associated to the "
-                                        "subscription request "))
+                raise ValidationError(
+                    _(
+                        "Can't confirm the payment. There is "
+                        "no transaction associated to the "
+                        "subscription request "
+                    )
+                )
 
     def post_process_confirm_sub_paid(self, effective_date):
         request = self.product_subscription_request

--- a/website_product_subscription_online_payment/models/product_subscription.py
+++ b/website_product_subscription_online_payment/models/product_subscription.py
@@ -22,12 +22,12 @@ class ProductSubscriptionRequest(models.Model):
     transaction_state = fields.Selection(
         related="payment_transaction.state",
         string="Transaction status",
-        readonly=True
+        readonly=True,
     )
     payment_type = fields.Selection(
         related="payment_transaction.payment_type",
         string="Payment Type",
-        store=True
+        store=True,
     )
 
     def send_invoice(self, invoice):

--- a/website_product_subscription_online_payment/views/online_payment_template.xml
+++ b/website_product_subscription_online_payment/views/online_payment_template.xml
@@ -38,10 +38,23 @@
         </xpath>
     </template>
 
-
     <template id="subscribe_gift_payment_type_form"
-        name="Subscribe Gift Payment Type Form"
-        inherit_id="website_product_subscription.subscribe_gift_form">
+              name="Subscribe Gift Payment Type Form"
+              inherit_id="website_product_subscription.subscribe_gift_form">
+        <xpath expr="//div[@name='captcha']" position="before">
+            <div name="payment_info">
+                <h3 class="title-payment col-lg-12">Payment</h3>
+                <t t-call="website_product_subscription_online_payment.payment_type_fields">
+                    <t t-set="field_class" t-value="'form-group col-lg-12'"/>
+                    <t t-set="input_class" t-value="'form-control'"/>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="subscribe_generic_payment_type_form"
+              name="Subscribe Generic Payment Type Form"
+              inherit_id="website_product_subscription.subscribe_generic_form">
         <xpath expr="//div[@name='captcha']" position="before">
             <div name="payment_info">
                 <h3 class="title-payment col-lg-12">Payment</h3>


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=3977&view_type=form&model=project.task&action=479)

**before**
If gifted subscriber exists, the subscription is blocked.

**after**
If gifted subscriber exists, the sponsor is prompted with an error message asking to check the sponsor address.
If the sponsor confirms, the subscriber address is updated.

**Notes**
I add the hidden fiends "address_checked" and "address checked for" in the form. When returning the error "check subscriber address, `address_checked` is set to `true`. On form re-confirmation, I can check the address was checked and that it still applies to the same email address.