### PR TITLE
[9.0] schedule gift emails send later

### DIFF
--- a/product_subscription/data/email_templates.xml
+++ b/product_subscription/data/email_templates.xml
@@ -11,15 +11,11 @@
       <field name="name">
         Subscription Payement Confirmation Email
       </field>
-      <field name="email_from">
-        ${(object.company_id.coop_email_contact or object.user_id.email)|safe}
-      </field>
+      <field name="email_from">${ctx.get('company').email|safe}</field>
       <field name="subject">Subscription payement confirmation</field>
       <field name="partner_to">${object.partner_id.id}</field>
       <!-- Is this reply address correct? -->
-      <field name="reply_to">
-        ${(object.company_id.coop_email_contact or object.user_id.email)|safe}
-      </field>
+      <field name="reply_to">${ctx.get('company').email|safe}</field>
       <field name="model_id" ref="model_account_invoice"/>
       <field name="auto_delete" eval="True"/>
       <field name="lang">${object.partner_id.lang}</field>

--- a/product_subscription/data/email_templates.xml
+++ b/product_subscription/data/email_templates.xml
@@ -16,6 +16,7 @@
       </field>
       <field name="subject">Subscription payement confirmation</field>
       <field name="partner_to">${object.partner_id.id}</field>
+      <!-- Is this reply address correct? -->
       <field name="reply_to">
         ${(object.company_id.coop_email_contact or object.user_id.email)|safe}
       </field>

--- a/product_subscription/models/account_move_line.py
+++ b/product_subscription/models/account_move_line.py
@@ -15,10 +15,9 @@ class AccountMoveLine(models.Model):
         # and we set back subscription request state to sent.
         for aml in self:
             invoice = aml.matched_debit_ids.debit_move_id.invoice_id
-            if (aml in invoice.payment_move_line_ids
-               and invoice.subscription):
+            if aml in invoice.payment_move_line_ids and invoice.subscription:
                 sub_req = invoice.product_subscription_request[0]
                 if sub_req.subscription:
                     sub_req.subscription.action_cancel()
-                sub_req.state = 'sent'
+                sub_req.state = "sent"
         return super(AccountMoveLine, self).remove_move_reconcile()

--- a/product_subscription/models/invoice.py
+++ b/product_subscription/models/invoice.py
@@ -39,10 +39,12 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def process_subscription(self, effective_date):
+        # todo should be delegated to subscription request
         self.ensure_one()
+        srequest = self.product_subscription_request
 
-        template = self.product_subscription_request.subscription_template
-        subscriber = self.product_subscription_request.subscriber
+        template = srequest.subscription_template
+        subscriber = srequest.subscriber
         try:
             effective_date = datetime.strptime(
                 effective_date, "%d/%m/%Y"
@@ -50,7 +52,12 @@ class AccountInvoice(models.Model):
         except ValueError:
             effective_date = effective_date
 
-        start_date = self.get_next_start_date(subscriber) or effective_date
+        if self.get_next_start_date(subscriber):
+            start_date = self.get_next_start_date(subscriber)
+        elif srequest.type == "gift" and srequest.gift_date:
+            start_date = srequest.gift_date
+        else:
+            start_date = effective_date
 
         subscription = self.env["product.subscription.object"].create(
             {
@@ -59,9 +66,9 @@ class AccountInvoice(models.Model):
                 "start_date": start_date,
                 "counter": template.product_qty,
                 "state": "ongoing",
-                "request": self.product_subscription_request.id,
+                "request": srequest.id,
                 "template": template.id,
-                "type": self.product_subscription_request.type,
+                "type": srequest.type,
             }
         )
 
@@ -74,7 +81,7 @@ class AccountInvoice(models.Model):
         if template.split_payment:
             vals["state"] = "sent"
 
-        self.product_subscription_request.write(vals)
+        srequest.write(vals)
 
         self.send_confirm_paid_email()
         return True
@@ -104,7 +111,7 @@ class AccountInvoice(models.Model):
                 and not refund
             ):
                 # seems that doing it this way strftime('%Y-%m-%d') doesn't
-                # work
+                # work  wtf
                 effective_date = datetime.now().strftime("%d/%m/%Y")
 
                 # take the effective date from the payment.

--- a/product_subscription/models/subscription_object.py
+++ b/product_subscription/models/subscription_object.py
@@ -32,7 +32,7 @@ class SubscriptionObject(models.Model):
             ("ongoing", "Ongoing"),
             ("renew", "Need to Renew"),
             ("terminated", "Terminated"),
-            ("cancel", "Cancelled")
+            ("cancel", "Cancelled"),
         ],
         string="State",
         default="draft",

--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -42,6 +42,8 @@ class SubscriptionRequest(models.Model):
     payment_date = fields.Date(
         string="Payment date", readonly=True, copy=False
     )
+    gift_date = fields.Date(string="Gift Date", required=False)
+    gift_sent = fields.Boolean(string="Gift Sent", default=False)
     invoice = fields.Many2one(
         comodel_name="account.invoice",
         string="Invoice",

--- a/product_subscription/models/subscription_request.py
+++ b/product_subscription/models/subscription_request.py
@@ -40,15 +40,13 @@ class SubscriptionRequest(models.Model):
         default=lambda _: fields.Date.today(),
     )
     payment_date = fields.Date(
-        string="Payment date",
-        readonly=True,
-        copy=False
+        string="Payment date", readonly=True, copy=False
     )
     invoice = fields.Many2one(
         comodel_name="account.invoice",
         string="Invoice",
         readonly=True,
-        copy=False
+        copy=False,
     )
     state = fields.Selection(
         [
@@ -138,7 +136,9 @@ class SubscriptionRequest(models.Model):
             invoicee = partner
 
         if invoicee.child_ids.filtered(lambda p: p.type == "invoice"):
-            invoicee = invoicee.child_ids.filtered(lambda p: p.type == "invoice")[0]
+            invoicee = invoicee.child_ids.filtered(
+                lambda p: p.type == "invoice"
+            )[0]
         else:
             invoicee = partner
 

--- a/product_subscription/tests/test_product_release.py
+++ b/product_subscription/tests/test_product_release.py
@@ -8,10 +8,10 @@ import datetime as dt
 
 
 class TestProductRelease(TransactionCase):
-
     def test_product_release_cycle(self):
         self.assertTrue(True)
         # too slow
+
     #     release_date = dt.date.today() + dt.timedelta(days=30)
     #     product_id = self.ref('product_subscription.demo_released_product_1')
     #     template_id = self.ref('product_subscription.demo_subscription_template_1')
@@ -37,4 +37,4 @@ class TestProductRelease(TransactionCase):
     #     self.assertEqual(release.state, 'done')
     #     self.assertEqual(len(release.picking_ids), 2)
 
-        # release.action_transfer()  # todo assign stock on product
+    # release.action_transfer()  # todo assign stock on product

--- a/product_subscription/views/subscription_views.xml
+++ b/product_subscription/views/subscription_views.xml
@@ -191,6 +191,8 @@
 			                <group>
 			                    <field name="sponsor" attrs="{'required':[('gift','=',True)]}"/>
 			                    <field name="subscription_date"/>
+			                    <field name="gift_date" attrs="{'invisible':[('gift', '=', False)]}"/>
+			                    <field name="gift_sent" attrs="{'invisible':[('gift', '=', False)]}"/>
 			                    <field name="payment_date"/>
 				               	<field name="invoice"/>
 			               	</group>

--- a/product_subscription_delivery/__openerp__.py
+++ b/product_subscription_delivery/__openerp__.py
@@ -6,7 +6,11 @@
 {
     "name": "Product Subscription Delivery",
     "version": "9.0.1.0.1",
-    "depends": ["product_subscription", "website_product_subscription", "delivery"],
+    "depends": [
+        "product_subscription",
+        "website_product_subscription",
+        "delivery",
+    ],
     "author": "Coop IT Easy SCRLfs",
     "category": "Sales",
     "website": "https://www.coopiteasy.be",

--- a/product_subscription_delivery/models/invoice.py
+++ b/product_subscription_delivery/models/invoice.py
@@ -32,8 +32,12 @@ class AccountInvoice(models.Model):
             carrier = invoice.carrier_id
             if carrier:
                 if invoice.state not in ("draft", "sent"):
-                    raise UserError(_("The invoice state have to be draft to"
-                                      "add delivery lines."))
+                    raise UserError(
+                        _(
+                            "The invoice state have to be draft to"
+                            "add delivery lines."
+                        )
+                    )
 
                 # The delivery type is based on fixed price
                 carrier = invoice.carrier_id.verify_carrier(

--- a/product_subscription_delivery/models/subscription.py
+++ b/product_subscription_delivery/models/subscription.py
@@ -28,8 +28,12 @@ class SubscriptionRequest(models.Model):
     def onchange_carrier(self):
         if self.carrier_id:
             if not self.carrier_id.verify_carrier(self.subscriber):
-                raise UserError(_("This carrier is not available for this"
-                                  "subscriber. Please select another one"))
+                raise UserError(
+                    _(
+                        "This carrier is not available for this"
+                        "subscriber. Please select another one"
+                    )
+                )
             else:
                 available_carriers = self.get_available_carriers(
                     self.subscriber

--- a/product_subscription_subscribers/__openerp__.py
+++ b/product_subscription_subscribers/__openerp__.py
@@ -10,7 +10,7 @@
     "author": "Coop IT Easy SCRLfs",
     "website": "https://coopiteasy.be",
     "license": "AGPL-3",
-    "depends": ["product_subscription", "website_product_subscription"], #
+    "depends": ["product_subscription", "website_product_subscription"],
     "data": [
         "templates/product_subscription_template.xml",
         "views/subscription_views.xml",

--- a/product_subscription_web_access/__openerp__.py
+++ b/product_subscription_web_access/__openerp__.py
@@ -7,7 +7,7 @@
 {
     "name": "Product Subscription Web Access",
     "version": "9.0.2.0.1",
-    "depends": ["product_subscription", "website_product_subscription"], #
+    "depends": ["product_subscription", "website_product_subscription"],
     "author": "Coop IT Easy SCRLfs",
     "category": "Sales",
     "website": "https://www.coopiteasy.be",

--- a/product_subscription_web_access/controllers/main.py
+++ b/product_subscription_web_access/controllers/main.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp.addons.website_product_subscription.controllers.subscribe import (
-    SubscribeController
+    SubscribeController,
 )
 from openerp import http
 from openerp.http import request

--- a/product_subscription_web_access/controllers/subscribe.py
+++ b/product_subscription_web_access/controllers/subscribe.py
@@ -5,12 +5,16 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp.http import request
-from openerp.addons.website_product_subscription.controllers.subscribe import SubscribeController
+from openerp.addons.website_product_subscription.controllers.subscribe import (
+    SubscribeController,
+)
 
 
 class SubscribeWebAccess(SubscribeController):
     def get_subscription_request_values(self):
-        vals = super(SubscribeWebAccess, self).get_subscription_request_values()
+        vals = super(
+            SubscribeWebAccess, self
+        ).get_subscription_request_values()
         params = request.params
         if params["is_gift"]:
             vals["websubscriber"] = params["subscriber_id"]

--- a/website_product_subscription/__openerp__.py
+++ b/website_product_subscription/__openerp__.py
@@ -20,6 +20,7 @@
      allow to subscribe online for a subscription template.
     """,
     "data": [
+        "data/cron.xml",
         "views/res_company.xml",
         "views/subscription_template_view.xml",
         "views/become_subscriber_menu.xml",

--- a/website_product_subscription/__openerp__.py
+++ b/website_product_subscription/__openerp__.py
@@ -21,6 +21,7 @@
     """,
     "data": [
         "data/cron.xml",
+        "data/mail_template.xml",
         "views/res_company.xml",
         "views/subscription_template_view.xml",
         "views/become_subscriber_menu.xml",

--- a/website_product_subscription/__openerp__.py
+++ b/website_product_subscription/__openerp__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     "name": "Website Product Subscription",
-    "version": "9.0.2.0.1",
+    "version": "9.0.2.1.0",
     "depends": [
         "base",
         "website",

--- a/website_product_subscription/controllers/subscribe.py
+++ b/website_product_subscription/controllers/subscribe.py
@@ -150,10 +150,9 @@ class SubscribeController(http.Controller):
         self._process_basic_subscriber()
 
         sub_req = self.create_subscription_request()
+        sub_req.create_web_access()
+
         params["sub_req_id"] = sub_req.id
-
-        self._create_web_access(params["login"], params["sponsor_id"])
-
         return sub_req
 
     def process_gift_form(self):
@@ -162,14 +161,9 @@ class SubscribeController(http.Controller):
         self._process_gift_subscriber()
 
         sub_req = self.create_subscription_request()
+        sub_req.create_web_access()
+
         params["sub_req_id"] = sub_req.id
-
-        if params["gift_date"] <= Date.today():
-            sub_req.gift_sent = True
-            self._create_web_access(
-                params["subscriber_login"], params["subscriber_id"]
-            )
-
         return sub_req
 
     def process_generic_form(self):
@@ -178,18 +172,9 @@ class SubscribeController(http.Controller):
         self._process_generic_subscriber()
 
         sub_req = self.create_subscription_request()
+        sub_req.create_web_access()
+
         params["sub_req_id"] = sub_req.id
-
-        if params["is_gift"] and params["gift_date"] <= Date.today():
-            login = params["subscriber_login"]
-            partner_id = params["subscriber_id"]
-            sub_req.gift_sent = True
-            self._create_web_access(login, partner_id)
-        else:
-            login = params["login"]
-            partner_id = params["sponsor_id"]
-            self._create_web_access(login, partner_id)
-
         return sub_req
 
     def _process_basic_sponsor(self):
@@ -430,9 +415,3 @@ class SubscribeController(http.Controller):
             )
             sponsor = partner_obj.sudo().create(sponsor_values)
         params["sponsor_id"] = sponsor.id if sponsor else False
-
-    def _create_web_access(self, email, partner_id):
-        user_obj = request.env["res.users"]
-
-        if not user_obj.user_exist(email):
-            user_obj.create_user({"login": email, "partner_id": partner_id})

--- a/website_product_subscription/controllers/subscribe.py
+++ b/website_product_subscription/controllers/subscribe.py
@@ -311,7 +311,9 @@ class SubscribeController(http.Controller):
                     "email": params["login"],
                 }
             )
-            company = request.env["res.partner"].sudo().create(shipping_address)
+            company = (
+                request.env["res.partner"].sudo().create(shipping_address)
+            )
             request.env.user.parent_id = company
         else:
             shipping_address.update(
@@ -322,7 +324,9 @@ class SubscribeController(http.Controller):
                     "email": params["login"],
                 }
             )
-            company = request.env["res.partner"].sudo().create(shipping_address)
+            company = (
+                request.env["res.partner"].sudo().create(shipping_address)
+            )
 
         params["company_id"] = company.id if company else False
         return company
@@ -352,7 +356,11 @@ class SubscribeController(http.Controller):
                     "lastname": params["lastname"],
                 }
             )
-            representative = request.env["res.partner"].sudo().create(representative_address)
+            representative = (
+                request.env["res.partner"]
+                .sudo()
+                .create(representative_address)
+            )
 
         params["sponsor_id"] = representative.id if representative else False
         return representative

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -76,7 +76,7 @@ class SubscribeForm:
                 "That does not seem to be an email address."
             )
 
-    def _validate_email_unique(self, email):
+    def _validate_sponsor_email_unique(self, email):
         other_users = (
             request.env["res.users"].sudo().search([("login", "=", email)])
         )
@@ -85,6 +85,15 @@ class SubscribeForm:
                 "There is an existing account for this mail "
                 "address. Please login before fill in the form"
             )
+
+    def _validate_subscriber_email_unique(self, email):
+        other_user = (
+            request.env["res.users"]
+            .sudo()
+            .search([("login", "=", email)], limit=1)
+        )
+        if other_user:
+            self.qcontext["gift_subscriber_exists"] = True
 
     def _validate_email_confirmation(self, email, confirm_email):
         if self.confirm:
@@ -123,13 +132,13 @@ class SubscribeForm:
             email = self.qcontext.get("login", False)
             confirm_email = self.qcontext.get("confirm_login")
             self._validate_email_format(email)
-            self._validate_email_unique(email)
+            self._validate_sponsor_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("subscriber_login", False):
             email = self.qcontext.get("subscriber_login", "")
             confirm_email = self.qcontext.get("subscriber_confirm_login")
             self._validate_email_format(email)
-            self._validate_email_unique(email)
+            self._validate_subscriber_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("vat", False):
             vat = self.qcontext.get("vat")

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -5,6 +5,7 @@
 
 from openerp import tools
 from openerp.http import request
+from openerp.fields import Date
 from openerp.tools.translate import _
 
 
@@ -69,6 +70,11 @@ class SubscribeForm:
             self.qcontext["is_gift"] = True
         else:
             self.qcontext["is_gift"] = False
+
+        if self.qcontext.get("subscriber_address_checked", False) == u"True":
+            self.qcontext["subscriber_address_checked"] = True
+        else:
+            self.qcontext["subscriber_address_checked"] = False
 
     def _validate_email_format(self, email):
         if not tools.single_email_re.match(email):
@@ -251,6 +257,9 @@ class SubscribeForm:
             self.qcontext["inv_country_id"] = default_country_id
         if "subscriber_country_id" not in self.qcontext or force:
             self.qcontext["subscriber_country_id"] = default_country_id
+
+        if "gift_date" not in self.qcontext or force:
+            self.qcontext["gift_date"] = Date.today()
 
     @property
     def user_fields(self):

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -127,9 +127,7 @@ class SubscribeForm:
             self._validate_email_confirmation(email, confirm_email)
         if self.qcontext.get("subscriber_login", False):
             email = self.qcontext.get("subscriber_login", "")
-            confirm_email = self.qcontext.get(
-                    "subscriber_confirm_login"
-                )
+            confirm_email = self.qcontext.get("subscriber_confirm_login")
             self._validate_email_format(email)
             self._validate_email_unique(email)
             self._validate_email_confirmation(email, confirm_email)
@@ -232,11 +230,11 @@ class SubscribeForm:
                     self.qcontext["invoice_address"] = False
         else:
             default_country_id = (
-                    request.env["res.company"]
-                    .sudo()
-                    ._company_default_get()
-                    .country_id.id
-                )
+                request.env["res.company"]
+                .sudo()
+                ._company_default_get()
+                .country_id.id
+            )
             if "country_id" not in self.qcontext or force:
                 self.qcontext["country_id"] = default_country_id
             if "inv_country_id" not in self.qcontext or force:

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -111,7 +111,7 @@ class SubscribeForm:
     def _validate_recaptcha(self):
         if self.captcha_check and "g-recaptcha-response" in self.qcontext:
             if not request.website.is_captcha_valid(
-                    self.qcontext.get("g-recaptcha-response", "")
+                self.qcontext.get("g-recaptcha-response", "")
             ):
                 self.qcontext["error"] = _(
                     "The captcha has not been validated, please fill "
@@ -170,8 +170,8 @@ class SubscribeForm:
                 "countries": self.get_countries(),
                 "subscriptions": (
                     request.env["product.subscription.template"]
-                        .sudo()
-                        .search([("publish", "=", True)])
+                    .sudo()
+                    .search([("publish", "=", True)])
                 ),
                 "company_condition_text": company_condition_text,
                 "user": self.user,
@@ -185,9 +185,9 @@ class SubscribeForm:
         """
         default_country_id = (
             request.env["res.company"]
-                .sudo()
-                ._company_default_get()
-                .country_id.id
+            .sudo()
+            ._company_default_get()
+            .country_id.id
         )
 
         if self.user:

--- a/website_product_subscription/controllers/subscribe_form.py
+++ b/website_product_subscription/controllers/subscribe_form.py
@@ -96,7 +96,7 @@ class SubscribeForm:
     def _validate_recaptcha(self):
         if self.captcha_check and "g-recaptcha-response" in self.qcontext:
             if not request.website.is_captcha_valid(
-                self.qcontext.get("g-recaptcha-response", "")
+                    self.qcontext.get("g-recaptcha-response", "")
             ):
                 self.qcontext["error"] = _(
                     "The captcha has not been validated, please fill "
@@ -155,8 +155,8 @@ class SubscribeForm:
                 "countries": self.get_countries(),
                 "subscriptions": (
                     request.env["product.subscription.template"]
-                    .sudo()
-                    .search([("publish", "=", True)])
+                        .sudo()
+                        .search([("publish", "=", True)])
                 ),
                 "company_condition_text": company_condition_text,
                 "user": self.user,
@@ -168,6 +168,13 @@ class SubscribeForm:
         Populate qcontext with the default value for the form. If user
         is set the default values are values of the user.
         """
+        default_country_id = (
+            request.env["res.company"]
+                .sudo()
+                ._company_default_get()
+                .country_id.id
+        )
+
         if self.user:
             user = None
             representative = None
@@ -193,7 +200,7 @@ class SubscribeForm:
                     self.qcontext["country_id"] = (
                         representative.country_id.id
                         if representative.country_id
-                        else 0
+                        else default_country_id
                     )
                 if "vat" not in self.qcontext or force:
                     self.qcontext["vat"] = user.vat
@@ -209,7 +216,7 @@ class SubscribeForm:
                         self.qcontext["inv_country_id"] = (
                             inv_address.country_id.id
                             if inv_address.country_id
-                            else 0
+                            else default_country_id
                         )
                     if "inv_zip_code" not in self.qcontext or force:
                         self.qcontext["inv_zip_code"] = inv_address.zip
@@ -228,19 +235,13 @@ class SubscribeForm:
                         self.qcontext[key] = getattr(user, key)
                 if "invoice_address" not in self.qcontext or force:
                     self.qcontext["invoice_address"] = False
-        else:
-            default_country_id = (
-                request.env["res.company"]
-                .sudo()
-                ._company_default_get()
-                .country_id.id
-            )
-            if "country_id" not in self.qcontext or force:
-                self.qcontext["country_id"] = default_country_id
-            if "inv_country_id" not in self.qcontext or force:
-                self.qcontext["inv_country_id"] = default_country_id
-            if "subscriber_country_id" not in self.qcontext or force:
-                self.qcontext["subscriber_country_id"] = default_country_id
+
+        if "country_id" not in self.qcontext or force:
+            self.qcontext["country_id"] = default_country_id
+        if "inv_country_id" not in self.qcontext or force:
+            self.qcontext["inv_country_id"] = default_country_id
+        if "subscriber_country_id" not in self.qcontext or force:
+            self.qcontext["subscriber_country_id"] = default_country_id
 
     @property
     def user_fields(self):

--- a/website_product_subscription/data/cron.xml
+++ b/website_product_subscription/data/cron.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2020 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+    <record id="ir_cron_create_scheduled_gift_user" model="ir.cron">
+        <field name="name">Create scheduled gift users</field>
+        <field name="interval_number">24</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field name="doall" eval="False"/>
+        <field name="model">product.subscription.request</field>
+        <field name="function">cron_create_scheduled_gift_user</field>
+        <field name="args">()</field>
+    </record>
+</odoo>
+

--- a/website_product_subscription/data/mail_template.xml
+++ b/website_product_subscription/data/mail_template.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2017-2018 Coop IT Easy SCRLfs - Rémy Taymans <remy@coopiteasy.be>
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+  <data noupdate="1">
+
+    <record id="gift_subscription_new_user_mail_template" model="mail.template">
+      <field name="name">
+        Gift Subscription Mail - New User
+      </field>
+      <field name="email_from">${ctx.get('company').email|safe}</field>
+      <field name="reply_to">${ctx.get('company').email|safe}</field>
+      <field name="subject">You have a new gift from ${object.subscriber.name} !</field>
+      <field name="partner_to">${object.subscriber.id}</field>
+      <field name="model_id" ref="model_product_subscription_request"/>
+      <field name="auto_delete" eval="True"/>
+      <field name="lang">${object.subscriber.lang}</field>
+      <field name="body_html">
+        <![CDATA[
+<div style="
+  font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif;
+  font-size: 12px; color: rgb(34, 34, 34);
+  background-color: #FFF;">
+
+<p>Hello ${object.subscriber.name},</p>
+
+<p>${object.sponsor.name} subscribed you to ${object.subscription_template.name}!</p>
+
+<p>You will receive an other email with login instructions.</p>
+
+</div>
+        ]]>
+      </field>
+    </record>
+
+    <record id="gift_subscription_existing_user_mail_template" model="mail.template">
+      <field name="name">
+        Gift Subscription Mail - Existing User
+      </field>
+      <field name="email_from">${ctx.get('company').email|safe}</field>
+      <field name="reply_to">${ctx.get('company').email|safe}</field>
+      <field name="subject">You have a new gift from ${object.subscriber.name}!
+      </field>
+      <field name="partner_to">${object.subscriber.id}</field>
+      <field name="model_id" ref="model_product_subscription_request"/>
+      <field name="auto_delete" eval="True"/>
+      <field name="lang">${object.subscriber.lang}</field>
+      <field name="body_html">
+        <![CDATA[
+<div style="
+  font-family: 'Lucica Grande', Ubuntu, Arial, Verdana, sans-serif;
+  font-size: 12px; color: rgb(34, 34, 34);
+  background-color: #FFF;">
+
+<p>Hello ${object.subscriber.name},</p>
+
+<p>${object.sponsor.name} subscribed you to ${object.subscription_template.name}!</p>
+
+<p>This subscription will start after your current subscription.</p>
+
+</div>
+        ]]>
+      </field>
+    </record>
+
+  </data>
+</odoo>

--- a/website_product_subscription/models/__init__.py
+++ b/website_product_subscription/models/__init__.py
@@ -1,3 +1,4 @@
+from . import subscription_request
 from . import subscription_template
 from . import res_company
 from . import res_users

--- a/website_product_subscription/models/__init__.py
+++ b/website_product_subscription/models/__init__.py
@@ -1,4 +1,5 @@
 from . import subscription_request
 from . import subscription_template
 from . import res_company
+from . import res_partner
 from . import res_users

--- a/website_product_subscription/models/res_partner.py
+++ b/website_product_subscription/models/res_partner.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, api
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    @api.model
+    def create_web_access(self):
+        User = self.env["res.users"]
+        for partner in self:
+            if not User.user_exists(partner.email):
+                User.create_user(
+                    {"login": partner.email, "partner_id": partner.id}
+                )

--- a/website_product_subscription/models/res_users.py
+++ b/website_product_subscription/models/res_users.py
@@ -15,7 +15,7 @@ class ResUsers(models.Model):
         user.with_context({"create_user": True}).action_reset_password()
         return user_id
 
-    def user_exist(self, login):
+    def user_exists(self, login):
         sudo_users = self.env["res.users"].sudo()
         user = sudo_users.search([("login", "=", login)])
         if user:

--- a/website_product_subscription/models/subscription_request.py
+++ b/website_product_subscription/models/subscription_request.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Coop IT Easy SCRL fs
+#   Robin Keunen <robin@coopiteasy.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import models, fields, api
+
+
+class SubscriptionRequest(models.Model):
+    _inherit = "product.subscription.request"
+
+    @api.model
+    def cron_create_scheduled_gift_user(self):
+        today = fields.Date.today()
+        requests = self.search(
+            [
+                ("gift", "=", True),
+                ("gift_sent", "=", False),
+                ("gift_date", "<=", today),
+            ]
+        )
+
+        for request in requests:
+            partner = request.subscriber
+            User = self.env["res.users"]
+
+            if not User.user_exist(partner.email):
+                User.create_user(
+                    {"login": partner.email, "partner_id": partner.id}
+                )
+            request.gift_sent = True
+
+            # fixme if beneficiary exists, no mail is sent and the user won't know he was subscribed

--- a/website_product_subscription/templates/components.xml
+++ b/website_product_subscription/templates/components.xml
@@ -277,6 +277,16 @@
             </select>
         </div>
 
+        <div t-attf-class="field-gift_date {{field_class}}">
+            <label for="gift_date">Gift date</label>
+            <input id="gift_date"
+                   t-att-class="input_class"
+                   type="date"
+                   name="gift_date"
+                   t-att-value="gift_date"
+                   required="required"/>
+        </div>
+
     </template>
 
     <template id="gift_fields" name="Gift Form Fields">
@@ -362,6 +372,16 @@
                     </option>
                 </t>
             </select>
+        </div>
+
+        <div t-attf-class="field-gift_date {{field_class}}">
+            <label for="gift_date">Gift date</label>
+            <input id="gift_date"
+                   t-att-class="input_class"
+                   type="date"
+                   name="gift_date"
+                   t-att-value="gift_date"
+                   required="required"/>
         </div>
 
     </template>

--- a/website_product_subscription/templates/subscribe_gift_form.xml
+++ b/website_product_subscription/templates/subscribe_gift_form.xml
@@ -11,6 +11,7 @@
                 <form method="post" class="row">
                     <input type="hidden" name="csrf_token"
                            t-att-value="request.csrf_token()"/>
+                    <input type="hidden" name="is_gift" t-att-value="'on'"/>
 
                     <p class="alert alert-danger col-lg-12" t-if="error"
                        role="alert">

--- a/website_product_subscription/templates/subscribe_thanks.xml
+++ b/website_product_subscription/templates/subscribe_thanks.xml
@@ -17,6 +17,13 @@
                                 <div class="alert alert-success">
                                     Your subscription has been successfully
                                     registered.
+                                    <t t-if="gift_subscriber_exists">
+                                        <div>
+                                            <span t-esc="sponsor_login"/>
+                                            was already in registered. He/she will
+                                            have the opportunity to check the delivery address in the gift email.
+                                        </div>
+                                    </t>
                                 </div>
                                 <div t-if="redirect_payment"
                                      class="oe_return_button">

--- a/website_product_subscription/tests/test_basic_route.py
+++ b/website_product_subscription/tests/test_basic_route.py
@@ -12,7 +12,6 @@ _logger = logging.getLogger(__name__)
 
 
 class TestBasicRoute(BaseProductSubscriptionCase):
-
     def test_new_subscription_basic_route_person(self):
         route = "/new/subscription/basic"
 

--- a/website_product_subscription_mollie_payment/__openerp__.py
+++ b/website_product_subscription_mollie_payment/__openerp__.py
@@ -6,7 +6,7 @@
     "name": "Website Product Subscription Mollie Payment",
     "version": "9.0.2.0.1",
     "depends": [
-        "website_product_subscription", #
+        "website_product_subscription",
         "website_product_subscription_online_payment",
         "payment_mollie_official",
     ],

--- a/website_product_subscription_mollie_payment/controllers/main.py
+++ b/website_product_subscription_mollie_payment/controllers/main.py
@@ -22,7 +22,7 @@ class ProductSubscriptionMollieController(MollieController):
         orderid = post["reference"]
         tx = pay_tx_obj.sudo().search([("reference", "=", orderid)])
         if tx and tx.product_subscription_request_id:
-            _logger.info('mollie redirect : tx status is %s' % tx.state)
+            _logger.info("mollie redirect : tx status is %s" % tx.state)
             if tx.state == "done":
                 route = "/render/online_payment_success"
             elif tx.state == "cancel":
@@ -30,8 +30,9 @@ class ProductSubscriptionMollieController(MollieController):
             elif tx.state == "error":
                 route = "/render/online_payment_error"
         elif tx:
-            _logger.info('mollie redirect : tx status is %s' % tx.state)
+            _logger.info("mollie redirect : tx status is %s" % tx.state)
         else:
-            _logger.info('mollie redirect : no tx found for reference %s' %
-                         orderid)
+            _logger.info(
+                "mollie redirect : no tx found for reference %s" % orderid
+            )
         return werkzeug.utils.redirect(route)

--- a/website_product_subscription_online_payment/controllers/main.py
+++ b/website_product_subscription_online_payment/controllers/main.py
@@ -19,9 +19,7 @@ class SubscribeOnlinePayment(SubscribeController):
         published_aquirers = pay_acq.search([("website_published", "=", True)])
         payment_types = []
         for acquirer in published_aquirers:
-            payment_types.append(
-                [acquirer.provider, acquirer.name.title()]
-            )
+            payment_types.append([acquirer.provider, acquirer.name.title()])
         return payment_types
 
     def fill_values(self, values, load_from_user=False):

--- a/website_product_subscription_online_payment/models/invoice.py
+++ b/website_product_subscription_online_payment/models/invoice.py
@@ -20,13 +20,20 @@ class AccountInvoice(models.Model):
                     ("origin", "=", invoice.move_name),
                 ]
             )
-            if sub_request.payment_transaction or not invoice.subscription \
-                    or refund:
+            if (
+                sub_request.payment_transaction
+                or not invoice.subscription
+                or refund
+            ):
                 super(AccountInvoice, invoice).confirm_paid()
             elif invoice.residual > 0 and not sub_request.payment_transaction:
-                raise ValidationError(_("Can't confirm the payment. There is "
-                                        "no transaction associated to the "
-                                        "subscription request "))
+                raise ValidationError(
+                    _(
+                        "Can't confirm the payment. There is "
+                        "no transaction associated to the "
+                        "subscription request "
+                    )
+                )
 
     def post_process_confirm_sub_paid(self, effective_date):
         request = self.product_subscription_request

--- a/website_product_subscription_online_payment/models/product_subscription.py
+++ b/website_product_subscription_online_payment/models/product_subscription.py
@@ -22,12 +22,12 @@ class ProductSubscriptionRequest(models.Model):
     transaction_state = fields.Selection(
         related="payment_transaction.state",
         string="Transaction status",
-        readonly=True
+        readonly=True,
     )
     payment_type = fields.Selection(
         related="payment_transaction.payment_type",
         string="Payment Type",
-        store=True
+        store=True,
     )
 
     def send_invoice(self, invoice):

--- a/website_product_subscription_online_payment/views/online_payment_template.xml
+++ b/website_product_subscription_online_payment/views/online_payment_template.xml
@@ -38,10 +38,23 @@
         </xpath>
     </template>
 
-
     <template id="subscribe_gift_payment_type_form"
-        name="Subscribe Gift Payment Type Form"
-        inherit_id="website_product_subscription.subscribe_gift_form">
+              name="Subscribe Gift Payment Type Form"
+              inherit_id="website_product_subscription.subscribe_gift_form">
+        <xpath expr="//div[@name='captcha']" position="before">
+            <div name="payment_info">
+                <h3 class="title-payment col-lg-12">Payment</h3>
+                <t t-call="website_product_subscription_online_payment.payment_type_fields">
+                    <t t-set="field_class" t-value="'form-group col-lg-12'"/>
+                    <t t-set="input_class" t-value="'form-control'"/>
+                </t>
+            </div>
+        </xpath>
+    </template>
+
+    <template id="subscribe_generic_payment_type_form"
+              name="Subscribe Generic Payment Type Form"
+              inherit_id="website_product_subscription.subscribe_generic_form">
         <xpath expr="//div[@name='captcha']" position="before">
             <div name="payment_info">
                 <h3 class="title-payment col-lg-12">Payment</h3>


### PR DESCRIPTION
[task](https://gestion.coopiteasy.be/web#id=5032&view_type=form&model=project.task&action=479)
Rebased on #28 

- adds gift_date and gift_sent to subscription.request
- start date of subscription is gift date if no subscription is active
- pass gift_date from form to request
- refactored `create_web_access`
  - to delay user creation for gift subscriptions
  - to delegate it to partner
- created email template to send to subscribers of gift subscriptions
  - one for existing user and the other for new user
- a cron is sending emails to scheduled gift subscriptions