### PR TITLE
[FIX] ps_web_access: trigger on web access

### DIFF
--- a/product_subscription/__openerp__.py
+++ b/product_subscription/__openerp__.py
@@ -6,7 +6,7 @@
 
 {
     "name": "Product Subscription",
-    "version": "9.0.3.0.0",
+    "version": "9.0.3.0.1",
     "depends": [
         "base",
         "account",

--- a/product_subscription_web_access/models/res_partner.py
+++ b/product_subscription_web_access/models/res_partner.py
@@ -30,7 +30,7 @@ class ResPartner(models.Model):
         "subscriptions.state",
         "subscriptions.start_date",
         "subscriptions.end_date",
-        "subscriptions.is_web_subscription",
+        "subscriptions.template.is_web_subscription",
     )
     def compute_is_web_subscribed(self):
         for partner in self:

--- a/product_subscription_web_access/models/subscription.py
+++ b/product_subscription_web_access/models/subscription.py
@@ -24,7 +24,8 @@ class ProductSubscriptionObject(models.Model):
     _inherit = "product.subscription.object"
 
     is_web_subscription = fields.Boolean(
-        related="template.is_web_subscription"
+        related="template.is_web_subscription",
+        readonly=True,
     )
 
     @api.model


### PR DESCRIPTION
- change of `is_web_subscription` on subscription is reported to the template => readonly
- depends is not triggered on related fields => depend on related model field

https://gestion.coopiteasy.be/web#id=5651&view_type=form&model=project.task&action=475&active_id=105