### PR TITLE
website_product_subscription: Do not re-create web access during validation

### DIFF
--- a/website_product_subscription/controllers/subscribe.py
+++ b/website_product_subscription/controllers/subscribe.py
@@ -100,7 +100,8 @@ class SubscribeController(http.Controller):
         self._process_subscriber()
 
         sub_req = self.create_subscription_request()
-        sub_req.create_web_access()
+        sub_req.send_gift_emails()
+        sub_req.mapped("subscriber").create_web_access()
 
         params["sub_req_id"] = sub_req.id
         return sub_req

--- a/website_product_subscription/data/cron.xml
+++ b/website_product_subscription/data/cron.xml
@@ -6,7 +6,7 @@
 <odoo>
     <record id="ir_cron_create_scheduled_gift_user" model="ir.cron">
         <field name="name">Create scheduled gift users</field>
-        <field name="interval_number">24</field>
+        <field name="interval_number">1</field>
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>
         <field name="doall" eval="False"/>
@@ -15,4 +15,3 @@
         <field name="args">()</field>
     </record>
 </odoo>
-

--- a/website_product_subscription/data/cron.xml
+++ b/website_product_subscription/data/cron.xml
@@ -6,7 +6,7 @@
 <odoo>
     <record id="ir_cron_create_scheduled_gift_user" model="ir.cron">
         <field name="name">Create scheduled gift users</field>
-        <field name="interval_number">1</field>
+        <field name="interval_number">24</field>
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>
         <field name="doall" eval="False"/>
@@ -15,3 +15,4 @@
         <field name="args">()</field>
     </record>
 </odoo>
+

--- a/website_product_subscription/models/res_partner.py
+++ b/website_product_subscription/models/res_partner.py
@@ -2,7 +2,11 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+import logging
+
 from openerp import models, api
+
+_logger = logging.getLogger(__name__)
 
 
 class ResPartner(models.Model):
@@ -16,6 +20,12 @@ class ResPartner(models.Model):
     @api.multi
     def create_web_access(self):
         for partner in self:
+            if not partner.email:
+                _logger.error(
+                    "partner %s %s does not have an email address; cannot create web access"
+                    % (partner.id, partner.name)
+                )
+                continue
             if not partner.has_web_access():
                 self.env["res.users"].create_user(
                     {"login": partner.email, "partner_id": partner.id}

--- a/website_product_subscription/models/res_partner.py
+++ b/website_product_subscription/models/res_partner.py
@@ -8,11 +8,15 @@ from openerp import models, api
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    @api.model
+    @api.multi
+    def has_web_access(self):
+        self.ensure_one()
+        return self.env["res.users"].user_exists(self.email)
+
+    @api.multi
     def create_web_access(self):
-        User = self.env["res.users"]
         for partner in self:
-            if not User.user_exists(partner.email):
-                User.create_user(
+            if not partner.has_web_access():
+                self.env["res.users"].create_user(
                     {"login": partner.email, "partner_id": partner.id}
                 )

--- a/website_product_subscription/models/subscription_request.py
+++ b/website_product_subscription/models/subscription_request.py
@@ -2,7 +2,6 @@
 #   Robin Keunen <robin@coopiteasy.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import datetime
 import logging
 
 from openerp import models, fields, api
@@ -56,22 +55,12 @@ class SubscriptionRequest(models.Model):
 
     @api.model
     def cron_create_scheduled_gift_user(self):
-        now = fields.Datetime.from_string(fields.Datetime.now()).time()
-        if now < datetime.time(7, 0, 0) or now > datetime.time(22, 0, 0):
-            # Don't send e-mails during hours meant for sleep.
-            _logger.info(
-                "Skipping cron_create_scheduled_gift_user because it's late: %s"
-                % now
-            )
-            return
-
+        today = fields.Date.today()
         requests = self.search(
             [
                 ("gift", "=", True),
                 ("gift_sent", "=", False),
-                # TODO: Revert following back to '<=' once the back log has
-                # cleared. (T3833)
-                ("gift_date", "=", fields.Date.today()),
+                ("gift_date", "<=", today),
             ]
         )
         for request in requests:

--- a/website_product_subscription/models/subscription_request.py
+++ b/website_product_subscription/models/subscription_request.py
@@ -11,7 +11,9 @@ class SubscriptionRequest(models.Model):
     @api.multi
     def validate_request(self):
         res = super(SubscriptionRequest, self).validate_request()
-        self.create_web_access()
+        for request in self:
+            if not self.env["res.users"].user_exists(request.subscriber.email):
+                request.create_web_access()
         return res
 
     @api.multi


### PR DESCRIPTION
When a subscriber already has web access, don't run create_web_access
again during validation.

Previously, when this was done on requests of type 'gift', the
subscriber would have received a second e-mail.

This behaviour was first introduced in: https://github.com/coopiteasy/product-subscription/commit/a79510803f502b375fb01e9260cc79b079bbfefd

Task: https://gestion.coopiteasy.be/web#id=6534&view_type=form&model=project.task&action=479