### PR TITLE
[FIX] website_product_subscription: Don't use removed method

### DIFF
--- a/website_product_subscription/models/subscription_request.py
+++ b/website_product_subscription/models/subscription_request.py
@@ -19,7 +19,7 @@ class SubscriptionRequest(models.Model):
             if not request.gift_sent:
                 request.send_gift_emails()
             if not request.subscriber.has_web_access():
-                request.create_web_access()
+                request.subscriber.create_web_access()
         return res
 
     @api.multi


### PR DESCRIPTION
subscription_request.create_web_access() was removed in favour of
res_partner.create_web_access(). This was somehow not caught. Oops.

