### PR TITLE
[FIX] website_product_subscription: On validation only send gifts for the correct date

### DIFF
--- a/website_product_subscription/controllers/subscribe.py
+++ b/website_product_subscription/controllers/subscribe.py
@@ -100,8 +100,9 @@ class SubscribeController(http.Controller):
         self._process_subscriber()
 
         sub_req = self.create_subscription_request()
-        sub_req.send_gift_emails()
-        sub_req.mapped("subscriber").create_web_access()
+        if sub_req.type != "gift" or sub_req.gift_date <= Date.today():
+            sub_req.send_gift_emails()
+            sub_req.subscriber.create_web_access()
 
         params["sub_req_id"] = sub_req.id
         return sub_req

--- a/website_product_subscription/models/subscription_request.py
+++ b/website_product_subscription/models/subscription_request.py
@@ -15,10 +15,13 @@ class SubscriptionRequest(models.Model):
     @api.multi
     def validate_request(self):
         res = super(SubscriptionRequest, self).validate_request()
+        today = fields.Date.today()
         for request in self:
-            if not request.gift_sent:
+            if (
+                request.type != "gift"
+                or (not request.gift_sent and request.gift_date <= today)
+            ):
                 request.send_gift_emails()
-            if not request.subscriber.has_web_access():
                 request.subscriber.create_web_access()
         return res
 


### PR DESCRIPTION
See T5134
<https://gestion.coopiteasy.be/web#id=7836&view_type=form&model=project.task>

In this case, subscriber accounts were created early without
accompanying gift e-mail. `send_gift_emails()` has a mechanism for not
sending e-mails early, but `create_web_access()` does not (and probably
should not).